### PR TITLE
Correct misspelling of architectures library.properties field name

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=ARDUINO Library for OLED Display VGY12864L-03.
 paragraph=The Arduino library for the display present has been developed to offer several methods to deal with display functionalities as discribed in the manual specifications.
 category=Display
 url=https://github.com/postfixNotation/OLED_LIB_VGY12864L_03
-architecture=*
+architectures=*


### PR DESCRIPTION
The correct spelling of the field name is architectures, not architecture.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format